### PR TITLE
サインイン & サインアップボタンを追加

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,10 @@ doks:
               item_url: '/custom-style/'
             - item_name: GeoJSON 仕様
               item_url: '/geojson/'
+            - item_name: サインイン
+              item_url: 'https://app.geolonia.com/#/signin'
+            - item_name: ユーザー登録
+              item_url: 'https://app.geolonia.com/#/signup'
 
     footer:
         content:

--- a/doks-theme/_includes/site-header.html
+++ b/doks-theme/_includes/site-header.html
@@ -23,12 +23,12 @@
 						{% endif %}
 					{% endif %}
 					{% if site.doks.header.nav %}
-						<ul class="site-header__nav hidden-xs">
+						<ul class="site-header__nav hidden-xs hidden-sm hidden-md">
 							{% for item in site.doks.header.nav %}
 								<li><a href="{% if jekyll.environment == 'production' %}{{ site.doks.baseurl }}{% endif %}{{ item.item_url }}">{{ item.item_name }}</a></li>
 							{% endfor %}
 						</ul><!-- /.site-header__nav -->
-						<button class="offcanvas-toggle visible-xs">
+						<button class="offcanvas-toggle visible-xs visible-sm visible-md">
 							<span></span>
 							<span></span>
 							<span></span>

--- a/doks-theme/_layouts/homepage.html
+++ b/doks-theme/_layouts/homepage.html
@@ -86,7 +86,7 @@
 					</div><!-- /.row -->
 				</div><!-- /.container -->
 
-				<div style="text-align: center;"><a class="btn btn--dark btn--rounded btn--w-icon btn--w-icon-left" href="https://app.geolonia.com/#/signup">いますぐ試す</a></div>
+				<div style="text-align: center;"><a class="btn btn--dark btn--rounded btn--w-icon btn--w-icon-left" href="https://app.geolonia.com/#/signup">アカウントを作成</a></div>
 			</div><!-- /.section -->
 		{% endif %}
 

--- a/doks-theme/assets/css/style.scss
+++ b/doks-theme/assets/css/style.scss
@@ -180,3 +180,51 @@ th
     margin: 0;
   }
 }
+
+.site-header__nav
+{
+  li:nth-last-child(1)
+  {
+    margin-left: 1rem;
+    a
+    {
+      background-color: #eb5c0b;
+      border-color: #eea236;
+      color: #fff;
+      padding: 10px 26px;
+      display: inline;
+      &:hover
+      {
+        background-color: #f39813;
+
+      }
+      &::-moz-selection {
+        background-color: #f39813;
+
+      }
+      &::selection {
+        background-color: #f39813;
+
+      }
+    }
+  }
+  li:nth-last-child(2)
+  {
+    a
+    {
+      border: 1px solid rgba(37,57,81,0.15);
+      padding: 10px 26px;
+      display: inline;
+      &:hover
+      {
+        background-color: rgba(255,255,255,0.45);
+      }
+      &::-moz-selection {
+        background-color: rgba(255,255,255,0.45);
+      }
+      &::selection {
+        background-color: rgba(255,255,255,0.45);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Close #26 

各子ページのヘッダーにサインイン & サインアップボタンを追加。
例： http://localhost:4000/tutorial/

![スクリーンショット 2021-09-10 14 44 10](https://user-images.githubusercontent.com/8760841/132805634-e5f022bc-3654-46f3-bcaf-f483c2d44279.png)

文言を「今すぐ試す」から「アカウントを作成」に変更。
![スクリーンショット 2021-09-10 14 40 01](https://user-images.githubusercontent.com/8760841/132805645-05cd2c66-5659-4a44-bae6-fc70aba8bf96.png)
