### PR TITLE
スマホで表示した時に、テーブルがはみ出る問題を修正

### DIFF
--- a/doks-theme/assets/css/style.scss
+++ b/doks-theme/assets/css/style.scss
@@ -141,6 +141,11 @@ th
   content: '';
 }
 
+.content table {
+  display: block;
+  overflow-x: auto;
+}
+
 .callout ul
 {
   margin: 0 1em;


### PR DESCRIPTION
Close #73 

以下のテーブルがスマホ時にはみ出ていたのでスクロールする様に修正

https://deploy-preview-75--geolonia-docs.netlify.app/geojson/#%E3%82%BF%E3%82%A4%E3%83%97%E3%81%94%E3%81%A8%E3%81%AB%E6%8C%87%E5%AE%9A%E5%8F%AF%E8%83%BD%E3%81%AA%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E6%83%85%E5%A0%B1