### PR TITLE
docs: 開発無料枠の対象に Cloudflare Pages / Workers を追記

### DIFF
--- a/tutorial/002.md
+++ b/tutorial/002.md
@@ -65,6 +65,7 @@ API キーを、テスト環境の `https://*.test` 及び、`http://127.0.0.1:<
 * GitHub Pages（`https://*.github.io`） ※ 独自ドメインは対象外。
 * Netlify (`https://*.netlify.com`, `https://*.netlify.app`) ※ 独自ドメインは対象外。
 * Vercel (`https://*.vercel.app`) ※ 独自ドメインは対象外。
+* Cloudflare Pages / Workers (`https://*.pages.dev`, `https://*.workers.dev`) ※ 独自ドメインは対象外。
 * [CodePen](https://codepen.io/)
 * [JSFiddle](https://jsfiddle.net/)
 * [CodeSandbox](https://codesandbox.io/)


### PR DESCRIPTION
## Summary

- 「対象となる URL およびサービス」一覧に Cloudflare Pages / Workers を追記
- `*.pages.dev` は referers.json に既に登録済みだったが、ドキュメントに記載がなかった
- `*.workers.dev` の追加に合わせてドキュメントも更新

関連: geolonia/free-referers#21

🤖 Generated with [Claude Code](https://claude.com/claude-code)